### PR TITLE
CORE-6353: Replace deprecated django importlib with standard library

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -3,8 +3,9 @@ import datetime
 from dateutil.parser import parse
 from decimal import Decimal, InvalidOperation
 import re
+import importlib
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
-from django.utils import datetime_safe, importlib
+from django.utils import datetime_safe
 from django.utils import six
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -4,9 +4,11 @@ from dateutil.parser import parse
 from decimal import Decimal, InvalidOperation
 import re
 import importlib
+
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils import datetime_safe
 from django.utils import six
+
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.utils import dict_strip_unicode_keys, make_aware


### PR DESCRIPTION
A tiny fix for deprecated module that is not available in Django 1.9: django.utils.importlib
New code is the same as in
https://github.com/django-tastypie/django-tastypie/blob/master/tastypie/fields.py#L7

More info on this deprecation message here:
https://stackoverflow.com/questions/29931979/recommended-practice-for-using-import-module-in-django-1-8

**NOTE**: This fix will NOT be automatically used in new environments, for that we will have to update this line in BE code: https://github.com/RevelSystems/Python-Backends/blob/master/revelV2/requirements.txt#L48
