### PR TITLE
CORE-6353 Remove usage of deprecated get_cache

### DIFF
--- a/tastypie/cache.py
+++ b/tastypie/cache.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.core.cache import get_cache
+from django.core.cache import caches
 
 
 class NoCache(object):
@@ -59,7 +59,7 @@ class SimpleCache(NoCache):
         Defaults to ``60`` seconds.
         """
         super(SimpleCache, self).__init__(*args, **kwargs)
-        self.cache = get_cache(cache_name)
+        self.cache = caches[cache_name]
         self.timeout = timeout or self.cache.default_timeout
         self.public = public
         self.private = private


### PR DESCRIPTION
https://revelup.atlassian.net/browse/CORE-6353

> django.core.cache.get_cache has been supplanted by django.core.cache.caches.

https://docs.djangoproject.com/en/1.11/releases/1.7/#django-core-cache-get-cache