### PR TITLE
CORE-7033 Copy same_origin function from Django

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import _sanitize_token, constant_time_compare
-from django.utils.http import same_origin
+from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext as _
 from tastypie.http import HttpUnauthorized
 from tastypie.compat import User, username_field
@@ -33,6 +33,23 @@ try:
     import oauth_provider
 except ImportError:
     oauth_provider = None
+
+
+def same_origin(url1, url2):
+    """
+    Checks if two URLs are 'same-origin'
+    """
+    PROTOCOL_TO_PORT = {
+        'http': 80,
+        'https': 443,
+    }
+    p1, p2 = urlparse(url1), urlparse(url2)
+    try:
+        o1 = (p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme])
+        o2 = (p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
+        return o1 == o2
+    except (ValueError, KeyError):
+        return False
 
 
 class Authentication(object):


### PR DESCRIPTION
https://revelup.atlassian.net/browse/CORE-7033

Fixes `ImportError: cannot import name same_origin`. The utility function was removed in Django 1.9

This is analogous to the commit in official Tastypie: https://github.com/django-tastypie/django-tastypie/commit/983b3aae9393779a61333a66c0807cdc5d48d7d6